### PR TITLE
Add DeleteServer helper method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# OpenStack Go Examples
+
+This project demonstrates basic interactions with the OpenStack Compute API using the [gophercloud](https://github.com/gophercloud/gophercloud) library.
+
+## Features
+
+- List servers
+- Create a new server
+- **Delete a server** using `DeleteServer` which waits for the deletion to complete
+
+The examples can be found in `cmd/main.go`.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -48,4 +48,11 @@ func main() {
 	}
 
 	fmt.Printf("Created new server: id=%s, name=%s\n", newServer.ID, newServer.Name)
+
+	// Delete the newly created server
+	fmt.Printf("Deleting server %s...\n", newServer.ID)
+	if err := client.DeleteServer(ctx, newServer.ID); err != nil {
+		log.Fatalf("Failed to delete server: %v", err)
+	}
+	fmt.Println("Server deleted")
 }


### PR DESCRIPTION
## Summary
- add DeleteServer to compute client using servers.Delete and WaitForStatus
- call DeleteServer from the CLI example
- document the new feature in README

## Testing
- `go vet ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68808ea86b28832bb89156c070e2a35b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to delete servers, including confirmation of successful deletion.
* **Documentation**
  * Introduced a README file describing project features and usage, including server listing, creation, and deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->