### PR TITLE
Implement server control and CLI flags

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"log"
 
@@ -15,11 +16,38 @@ func main() {
 		log.Printf("Warning: Could not load .env file: %v", err)
 	}
 
+	// Command line flags for basic server actions
+	startID := flag.String("start", "", "ID of server to start")
+	stopID := flag.String("stop", "", "ID of server to stop")
+	rebootID := flag.String("reboot", "", "ID of server to reboot")
+	flag.Parse()
+
 	ctx := context.Background()
 
 	client, err := openstack.NewClient(ctx)
 	if err != nil {
 		log.Fatalf("Failed to create OpenStack client: %v", err)
+	}
+
+	if *startID != "" {
+		if err := client.StartServer(ctx, *startID); err != nil {
+			log.Fatalf("Failed to start server: %v", err)
+		}
+		fmt.Printf("Started server %s\n", *startID)
+	}
+
+	if *stopID != "" {
+		if err := client.StopServer(ctx, *stopID); err != nil {
+			log.Fatalf("Failed to stop server: %v", err)
+		}
+		fmt.Printf("Stopped server %s\n", *stopID)
+	}
+
+	if *rebootID != "" {
+		if err := client.RebootServer(ctx, *rebootID); err != nil {
+			log.Fatalf("Failed to reboot server: %v", err)
+		}
+		fmt.Printf("Rebooted server %s\n", *rebootID)
 	}
 
 	// List servers example

--- a/internal/openstack/compute.go
+++ b/internal/openstack/compute.go
@@ -59,3 +59,22 @@ func (c *Client) CreateServer(ctx context.Context, config ServerConfig) (*server
 func (c *Client) GetFlavor(ctx context.Context, flavorID string) (*flavors.Flavor, error) {
 	return flavors.Get(ctx, c.Compute, flavorID).Extract()
 }
+
+// StartServer issues a start action for a shutoff server.
+// The server should transition from the SHUTOFF state to ACTIVE.
+func (c *Client) StartServer(ctx context.Context, serverID string) error {
+	return servers.Start(ctx, c.Compute, serverID).ExtractErr()
+}
+
+// StopServer issues a stop action for a running server.
+// The server should transition from ACTIVE to SHUTOFF once the operation completes.
+func (c *Client) StopServer(ctx context.Context, serverID string) error {
+	return servers.Stop(ctx, c.Compute, serverID).ExtractErr()
+}
+
+// RebootServer reboots the specified server using a soft reboot.
+// If the soft reboot fails the server may remain in the ACTIVE state.
+func (c *Client) RebootServer(ctx context.Context, serverID string) error {
+	opts := servers.RebootOpts{Type: servers.SoftReboot}
+	return servers.Reboot(ctx, c.Compute, serverID, opts).ExtractErr()
+}


### PR DESCRIPTION
## Summary
- add server start, stop and reboot methods
- expose command-line flags in example CLI to call these methods

## Testing
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68808eaa0abc832b9db1584a8b312a28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to start, stop, or reboot servers using new command-line options.
  * Users now receive confirmation messages when these actions are performed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->