### PR TITLE
Add flavor listing support and display in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This project demonstrates basic interactions with the OpenStack Compute API usin
 ## Features
 
 - List servers
+- List flavors
 - Create a new server
 - **Delete a server** using `DeleteServer` which waits for the deletion to complete
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -61,6 +61,17 @@ func main() {
 		fmt.Printf("  server %d: id=%s, name=%s\n", i, server.ID, server.Name)
 	}
 
+	// List flavors example
+	flavorList, err := client.ListFlavors(ctx)
+	if err != nil {
+		log.Fatalf("Failed to list flavors: %v", err)
+	}
+
+	fmt.Println("Available flavors:")
+	for i, flavor := range flavorList {
+		fmt.Printf("  flavor %d: id=%s, name=%s, vcpus=%d, ram=%dMB, disk=%dGB\n", i, flavor.ID, flavor.Name, flavor.VCPUs, flavor.RAM, flavor.Disk)
+	}
+
 	// Create server example
 	config := openstack.ServerConfig{
 		Name:           "test-server",

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module example.com/go-openstack/v2
 
 go 1.23.2
 
-require github.com/gophercloud/gophercloud/v2 v2.2.0
+require github.com/gophercloud/gophercloud/v2 v2.8.0
 
 require github.com/joho/godotenv v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/gophercloud/gophercloud/v2 v2.2.0 h1:STqqnSXuhcg1OPBOZ14z6JDm8fKIN13H2bJg6bBuHp8=
-github.com/gophercloud/gophercloud/v2 v2.2.0/go.mod h1:f2hMRC7Kakbv5vM7wSGHrIPZh6JZR60GVHryJlF/K44=
+github.com/gophercloud/gophercloud/v2 v2.8.0 h1:of2+8tT6+FbEYHfYC8GBu8TXJNsXYSNm9KuvpX7Neqo=
+github.com/gophercloud/gophercloud/v2 v2.8.0/go.mod h1:Ki/ILhYZr/5EPebrPL9Ej+tUg4lqx71/YH2JWVeU+Qk=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=


### PR DESCRIPTION
## Summary
- add Compute client's `ListFlavors` for enumerating available flavors
- show available flavors in CLI alongside server listings
- document flavor listing capability in README
- update gophercloud dependency and adjust delete waiter logic

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ba9267da04833391fdd7ac6730f0e3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added CLI support to list available flavors, showing ID, name, vCPUs, RAM (MB), and disk (GB).
- Documentation
  - Updated README Features list to include “List flavors.”
- Chores
  - Updated cloud SDK dependency to a newer version for compatibility and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->