### PR TITLE
Add server snapshot creation and CLI flag

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,6 +20,8 @@ func main() {
 	startID := flag.String("start", "", "ID of server to start")
 	stopID := flag.String("stop", "", "ID of server to stop")
 	rebootID := flag.String("reboot", "", "ID of server to reboot")
+	snapshotID := flag.String("snapshot", "", "ID of server to snapshot")
+	snapshotName := flag.String("snapshot-name", "", "Name of image to create")
 	flag.Parse()
 
 	ctx := context.Background()
@@ -48,6 +50,18 @@ func main() {
 			log.Fatalf("Failed to reboot server: %v", err)
 		}
 		fmt.Printf("Rebooted server %s\n", *rebootID)
+	}
+
+	if *snapshotID != "" {
+		name := *snapshotName
+		if name == "" {
+			name = fmt.Sprintf("%s-snapshot", *snapshotID)
+		}
+		imageID, err := client.CreateImage(ctx, *snapshotID, name)
+		if err != nil {
+			log.Fatalf("Failed to create image: %v", err)
+		}
+		fmt.Printf("Created image %s from server %s\n", imageID, *snapshotID)
 	}
 
 	// List servers example


### PR DESCRIPTION
## Summary
- add `Client.CreateImage` helper to snapshot servers and return image IDs
- expose `-snapshot` and `-snapshot-name` CLI flags to create snapshots from the command line
- update server deletion to use `ResponseCodeIs` when waiting for removal

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ba97860d388333b2617c6159cd7a5a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI flags --snapshot and --snapshot-name to create a snapshot of a running server, printing the created image ID on success.

* **Bug Fixes**
  * Improved server deletion reliability by waiting until resources are fully removed.
  * Enhanced handling of “not found” responses during deletion to avoid misleading errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->