### PR TITLE
Add helper for fetching server details

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,6 +20,7 @@ func main() {
 	startID := flag.String("start", "", "ID of server to start")
 	stopID := flag.String("stop", "", "ID of server to stop")
 	rebootID := flag.String("reboot", "", "ID of server to reboot")
+	getID := flag.String("get", "", "ID of server to fetch details")
 	flag.Parse()
 
 	ctx := context.Background()
@@ -48,6 +49,14 @@ func main() {
 			log.Fatalf("Failed to reboot server: %v", err)
 		}
 		fmt.Printf("Rebooted server %s\n", *rebootID)
+	}
+
+	if *getID != "" {
+		server, err := client.GetServer(ctx, *getID)
+		if err != nil {
+			log.Fatalf("Failed to get server: %v", err)
+		}
+		fmt.Printf("Fetched server %s: name=%s status=%s\n", server.ID, server.Name, server.Status)
 	}
 
 	// List servers example

--- a/internal/openstack/compute.go
+++ b/internal/openstack/compute.go
@@ -62,6 +62,10 @@ func (c *Client) GetFlavor(ctx context.Context, flavorID string) (*flavors.Flavo
 	return flavors.Get(ctx, c.Compute, flavorID).Extract()
 }
 
+// GetServer retrieves server details by ID
+func (c *Client) GetServer(ctx context.Context, serverID string) (*servers.Server, error) {
+	return servers.Get(ctx, c.Compute, serverID).Extract()
+}
 
 // StartServer issues a start action for a shutoff server.
 func (c *Client) StartServer(ctx context.Context, serverID string) error {


### PR DESCRIPTION
## Summary
- add `GetServer` wrapper around `servers.Get`
- support fetching server details via `-get` in sample CLI

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ba9765a9108333b80f88428e6f0bc5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a CLI flag to fetch server details by ID, displaying the server’s ID, name, and status.
  * Integrates seamlessly with existing commands, executing after reboot handling and before listing servers.
  * No changes to existing public APIs or command behaviors outside this addition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->